### PR TITLE
Buck the spec, move to above dialogs

### DIFF
--- a/paper-snackbar.html
+++ b/paper-snackbar.html
@@ -23,7 +23,7 @@
         box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
         color: var(--paper-snackbar-text);
         width: 600px;
-        padding: 12px;
+        padding: 16px;
         visibility: hidden;
         text-align: center;
         will-change: transform;
@@ -34,6 +34,7 @@
         transition-duration: 0.2s;
         font-family: 'Roboto', 'Noto', sans-serif;
         -webkit-font-smoothing: antialiased;
+        z-index: 105;
       }
 
       :host(.opened) {
@@ -51,7 +52,6 @@
           width: auto;
           -webkit-transform: translate3d(0, 100%, 0);
           transform: translate3d(0, 100%, 0);
-          z-index: 1;
         }
       }
 


### PR DESCRIPTION
Spec says 
> Snackbars appear above most elements on screen...However, they are lower in elevation than dialogs, bottom sheets, and navigation drawers."

This is somewhat annoying depending on what you're trying to accomplish. To resolve #1 We push the z-index up above the base level likely to be seen when using paper-dialog (z-index: 103, based on iron-overlay-behavior).